### PR TITLE
Add skill forge lab, /mobius-profile skill, and ideas backlog

### DIFF
--- a/.claude/skills/mobius-profile/SKILL.md
+++ b/.claude/skills/mobius-profile/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: mobius-profile
+description: Use when you want to analyze a specific agent's performance history, recent matches, win/loss record, or find challenging opponents for an agent.
+user-invocable: true
+argument-hint: <agent-slug>
+---
+
+# Mobius Agent Profile
+
+Get a detailed performance breakdown for a single agent: their Elo rating, win rate, recent matches, key wins and losses, and recommended challengers.
+
+## What to do
+
+1. **Load the agent profile:**
+```bash
+python .claude/skills/mobius-profile/scripts/show_profile.py <agent-slug>
+```
+
+This outputs:
+- Basic stats: Elo, win rate, total matches, generation, specializations
+- Last 10 matches with opponents and outcomes
+- Top 3 opponents they beat (by frequency)
+- Top 3 opponents who beat them (by frequency)
+- Recommended challengers: agents with opposite specializations or high win rates they haven't faced
+
+2. **Interpret the profile:**
+   - **Elo rating**: 1500 = average. Above 1700 = expert tier. Below 1300 = improving.
+   - **Win rate**: How often they win. Track trends — improving vs. declining?
+   - **Match history**: Are they losing to specific types of agents?
+   - **Recommended challengers**: These agents exploit gaps in this agent's strength profile.
+
+3. **Make decisions:**
+   - If win rate is dropping, the agent may need evolution (`/mobius-judge` to judge their recent losses, then `mobius evolve <spec>`)
+   - If they beat a specific opponent often, they may be over-specialized
+   - If recommended challengers are all from one provider (e.g., "all Google"), they may struggle with that provider's style
+
+## Pro Tips
+
+- Run profiles for your **champions** before entering a long-running tournament to understand their strengths
+- Compare two agents side-by-side by running profiles for both and looking at their match history overlap
+- If an agent has only 1-2 total matches, they need more tournament exposure before drawing conclusions
+- The "recommended challengers" list is smart: it prioritizes agents you haven't faced and agents with complementary specializations

--- a/.claude/skills/mobius-profile/scripts/show_profile.py
+++ b/.claude/skills/mobius-profile/scripts/show_profile.py
@@ -6,14 +6,13 @@ Usage:
 Outputs: Basic stats, recent match history, win/loss analysis, and recommended challengers.
 """
 
-import json
 import sys
 from collections import Counter
 
 sys.path.insert(0, "src")
 
 from mobius.config import get_config
-from mobius.db import init_db, row_to_dict
+from mobius.db import init_db
 from mobius.registry import Registry
 from mobius.tournament import Tournament
 
@@ -65,10 +64,15 @@ def main():
         print(f"  RECENT MATCHES (last 10)")
         print(f"{'='*60}\n")
 
-        opponent_wins = Counter()
-        opponent_losses = Counter()
+        opponent_wins = Counter()  # keyed by slug
+        opponent_losses = Counter()  # keyed by slug
+        slug_to_name = {}  # slug -> display name
 
         for i, match in enumerate(matches, 1):
+            # Skip voided/undecided matches
+            if match.winner_id is None:
+                continue
+
             is_win = match.winner_id == agent.id
             outcome = "WIN " if is_win else "LOSS"
 
@@ -77,13 +81,16 @@ def main():
             opponent_names = []
             for opp_id in opponents:
                 opp = registry.get_agent(opp_id)
+                opp_slug = opp.slug if opp else opp_id[:8]
                 opp_name = opp.name if opp else opp_id[:8]
+                slug_to_name[opp_slug] = opp_name
                 opponent_names.append(opp_name)
 
                 if is_win:
-                    opponent_wins[opp_name] += 1
-                else:
-                    opponent_losses[opp_name] += 1
+                    opponent_wins[opp_slug] += 1
+                elif opp_id == match.winner_id:
+                    # Only count loss against the actual winner
+                    opponent_losses[opp_slug] += 1
 
             vs_text = " vs ".join(opponent_names)
             task_preview = match.task_description[:50].replace("\n", " ")
@@ -98,14 +105,14 @@ def main():
 
         if opponent_wins:
             print(f"Defeated most often:")
-            for name, count in opponent_wins.most_common(3):
-                print(f"  • {name} ({count}x)")
+            for slug, count in opponent_wins.most_common(3):
+                print(f"  • {slug_to_name.get(slug, slug)} ({count}x)")
             print()
 
         if opponent_losses:
             print(f"Lost to most often:")
-            for name, count in opponent_losses.most_common(3):
-                print(f"  • {name} ({count}x)")
+            for slug, count in opponent_losses.most_common(3):
+                print(f"  • {slug_to_name.get(slug, slug)} ({count}x)")
             print()
 
     else:
@@ -129,6 +136,7 @@ def main():
     candidates = [
         a for a in all_agents
         if a.id != agent.id and a.id not in recent_opponent_ids
+        and a.elo_rating > 0 and a.total_matches > 0
     ]
 
     if not candidates:

--- a/.claude/skills/mobius-profile/scripts/show_profile.py
+++ b/.claude/skills/mobius-profile/scripts/show_profile.py
@@ -1,0 +1,168 @@
+"""Show detailed performance profile for a single agent.
+
+Usage:
+    python show_profile.py <agent-slug>
+
+Outputs: Basic stats, recent match history, win/loss analysis, and recommended challengers.
+"""
+
+import json
+import sys
+from collections import Counter
+
+sys.path.insert(0, "src")
+
+from mobius.config import get_config
+from mobius.db import init_db, row_to_dict
+from mobius.registry import Registry
+from mobius.tournament import Tournament
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: python show_profile.py <agent-slug>")
+        sys.exit(1)
+
+    slug = sys.argv[1]
+    config = get_config()
+    conn, _ = init_db(config)
+    registry = Registry(conn, config)
+    tournament = Tournament(conn, config, registry)
+
+    # Get agent
+    agent = registry.get_agent_by_slug(slug)
+    if not agent:
+        print(f"Agent '{slug}' not found.")
+        sys.exit(1)
+
+    # ===== BASIC STATS =====
+    print(f"\n{'='*60}")
+    print(f"  AGENT PROFILE: {agent.name}")
+    print(f"{'='*60}\n")
+
+    print(f"Slug:              {agent.slug}")
+    print(f"ID:                {agent.id[:8]}...")
+    print(f"Provider:          {agent.provider}/{agent.model.split('/')[-1][:20]}")
+    print(f"Specializations:   {', '.join(agent.specializations) if agent.specializations else '(none)'}")
+    print(f"Generation:        {agent.generation}")
+    if agent.parent_id:
+        parent = registry.get_agent(agent.parent_id)
+        parent_name = parent.name if parent else agent.parent_id[:8]
+        print(f"Parent:            {parent_name}")
+    print(f"Champion:          {'Yes' if agent.is_champion else 'No'}")
+    print()
+
+    # ===== PERFORMANCE STATS =====
+    print(f"Elo Rating:        {agent.elo_rating:.0f}")
+    print(f"Win Rate:          {agent.win_rate:.1%} ({int(agent.win_rate * agent.total_matches)}/{agent.total_matches} matches)")
+    print(f"Total Matches:     {agent.total_matches}")
+    print()
+
+    # ===== RECENT MATCHES =====
+    matches = tournament.get_agent_matches(agent.id, limit=10)
+    if matches:
+        print(f"{'='*60}")
+        print(f"  RECENT MATCHES (last 10)")
+        print(f"{'='*60}\n")
+
+        opponent_wins = Counter()
+        opponent_losses = Counter()
+
+        for i, match in enumerate(matches, 1):
+            is_win = match.winner_id == agent.id
+            outcome = "WIN " if is_win else "LOSS"
+
+            # Find opponent(s)
+            opponents = [cid for cid in match.competitor_ids if cid != agent.id]
+            opponent_names = []
+            for opp_id in opponents:
+                opp = registry.get_agent(opp_id)
+                opp_name = opp.name if opp else opp_id[:8]
+                opponent_names.append(opp_name)
+
+                if is_win:
+                    opponent_wins[opp_name] += 1
+                else:
+                    opponent_losses[opp_name] += 1
+
+            vs_text = " vs ".join(opponent_names)
+            task_preview = match.task_description[:50].replace("\n", " ")
+            print(f"{i:2}. [{outcome}] {vs_text}")
+            print(f"    Task: {task_preview}{'...' if len(match.task_description) > 50 else ''}")
+            print()
+
+        # ===== WIN/LOSS ANALYSIS =====
+        print(f"{'='*60}")
+        print(f"  WIN/LOSS ANALYSIS")
+        print(f"{'='*60}\n")
+
+        if opponent_wins:
+            print(f"Defeated most often:")
+            for name, count in opponent_wins.most_common(3):
+                print(f"  • {name} ({count}x)")
+            print()
+
+        if opponent_losses:
+            print(f"Lost to most often:")
+            for name, count in opponent_losses.most_common(3):
+                print(f"  • {name} ({count}x)")
+            print()
+
+    else:
+        print(f"No matches yet. Agent needs tournament exposure.")
+        print()
+
+    # ===== RECOMMENDED CHALLENGERS =====
+    print(f"{'='*60}")
+    print(f"  RECOMMENDED CHALLENGERS")
+    print(f"{'='*60}\n")
+
+    # Get all agents
+    all_agents = registry.list_agents()
+
+    # Filter: exclude self, exclude agents in recent matches
+    recent_opponent_ids = set()
+    if matches:
+        for match in matches:
+            recent_opponent_ids.update(match.competitor_ids)
+
+    candidates = [
+        a for a in all_agents
+        if a.id != agent.id and a.id not in recent_opponent_ids
+    ]
+
+    if not candidates:
+        print("No unused challengers available.")
+        print()
+    else:
+        # Score candidates: prefer high win rate + different specializations
+        scored = []
+        agent_specs = set(agent.specializations)
+
+        for cand in candidates:
+            score = 0
+            # High win rate (up to 50 points)
+            score += int(cand.win_rate * 50)
+            # Different specializations (up to 30 points)
+            cand_specs = set(cand.specializations)
+            if not (agent_specs & cand_specs):  # no overlap
+                score += 30
+            # High Elo (up to 20 points)
+            score += int(min(cand.elo_rating / 2000 * 20, 20))
+
+            scored.append((cand, score))
+
+        scored.sort(key=lambda x: x[1], reverse=True)
+
+        for i, (cand, score) in enumerate(scored[:5], 1):
+            specs = ", ".join(cand.specializations) if cand.specializations else "(none)"
+            print(f"{i}. {cand.name}")
+            print(f"   Elo: {cand.elo_rating:.0f} | Win Rate: {cand.win_rate:.1%}")
+            print(f"   Specializations: {specs}")
+            print()
+
+    conn.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/README.md
+++ b/README.md
@@ -113,8 +113,9 @@ Created: Protocol Engineer (anthropic/claude-sonnet-4-6)   specs=[coding, archit
 Created: Test Specialist (anthropic/claude-sonnet-4-6)     specs=[testing, debugging]
 Created: Dashboard Dev (anthropic/claude-sonnet-4-6)       specs=[frontend, coding]
 Created: Spec Auditor (anthropic/claude-sonnet-4-6)        specs=[security, code-review]
+Created: Perf Optimizer (google/gemini-2.5-flash)          specs=[backend, algorithms]
 
-Scout created 4 agents for my-project.
+Scout created 5 agents for my-project.
 ```
 
 > Record your own: `asciinema rec demo.cast` then run some competitions. Scripts in `scripts/`.
@@ -142,6 +143,7 @@ mobius explain                  # Show last match's judge reasoning
 mobius stats                    # Overview
 mobius agent list               # Browse agents
 mobius agent show <slug>        # Agent details
+mobius agent export <slug>      # Export agent as .claude/agents/ markdown
 ```
 
 ## Claude Code Skills (Free)
@@ -227,7 +229,7 @@ Costs below are for typical tasks (500-2000 tokens per agent attempt):
 
 **Claude Code users**: `/mobius-seed` and `/mobius-judge` use your Opus subscription directly — same quality, zero API cost. API calls are only needed for `mobius bootstrap` (one-time) and automated loops.
 
-*Costs estimated March 2025. Verify current pricing in your provider dashboards.*
+*Costs estimated March 2026. Verify current pricing in your provider dashboards.*
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Task → Memory Query → Selector → Swarm (parallel) → Judge Panel → Elo 
   - **Anthropic** (Claude) — recommended, used by default judge panel
   - **Google** (Gemini) — optional, adds provider diversity
   - **OpenAI** (GPT) — optional, adds provider diversity
-- **Claude Code Pro/Team** — optional, enables free agent seeding and judging via skills
+- **Claude Code subscription** — optional, enables free agent seeding and judging via skills
 
 ### Install & run
 
@@ -64,7 +64,7 @@ Bootstrap agents (choose one):
 # Option A: API-driven (~$1.50 one-time cost, automated)
 mobius bootstrap
 
-# Option B: Claude Code (free, requires Pro/Team subscription)
+# Option B: Claude Code (free, requires any Claude Code subscription)
 # In Claude Code, type: /mobius-seed
 
 # Option C: Domain-specific (uses Opus API to analyze your codebase, ~$0.50)
@@ -150,7 +150,7 @@ mobius agent export <slug>      # Export agent as .claude/agents/ markdown
 
 ## Claude Code Skills (Free)
 
-If you use [Claude Code](https://claude.com/claude-code) with a Pro/Team subscription, these skills replace the paid API equivalents:
+If you use [Claude Code](https://claude.com/claude-code) with any Claude Code subscription, these skills replace the paid API equivalents:
 
 | Skill | Replaces | What it does |
 |-------|----------|-------------|

--- a/README.md
+++ b/README.md
@@ -15,7 +15,9 @@ judges them with a cross-family panel, and evolves the winners — across Anthro
 
 ---
 
-Most agent frameworks run one model, hope for the best, and call it done. Mobius takes a different approach: **run multiple agents in parallel, have independent judges score them, and evolve the winners.**
+Most agent frameworks run one model, hope for the best, and call it done. Mobius takes a different approach: **competition drives quality.**
+
+Run multiple agents in parallel, have independent judges score them, and evolve the winners.
 
 - **5 agents** (configurable) tackle every task in parallel — different providers, different strategies
 - **3 judges** from different model families score the outputs (reduces single-provider bias)

--- a/README.md
+++ b/README.md
@@ -15,13 +15,21 @@ judges them with a cross-family panel, and evolves the winners — across Anthro
 
 ---
 
-Most agent frameworks run one model, hope for the best, and call it done. Mobius takes a different approach: **competition drives quality.**
+Most agent frameworks run one model, hope for the best, and call it done. Mobius takes a different approach: **run multiple agents in parallel, have independent judges score them, and evolve the winners.**
 
 - **5 agents** (configurable) tackle every task in parallel — different providers, different strategies
 - **3 judges** from different model families score the outputs (reduces single-provider bias)
 - **Elo ratings** track who's actually good, not who's hyped
 - **Evolution** breeds winners into new variants; underperformers get retired
 - **Memory** remembers which agents won on similar tasks, so selection gets smarter over time
+
+**When Mobius is worth it:**
+- You're uncertain which model/provider is best for your task
+- Output quality varies between runs and you need consistency
+- You want long-term performance tracking as models change
+- You're willing to spend 3-5x more tokens for statistically better outputs
+
+For simple tasks with predictable outputs, a single good model is fine. Mobius is for problems where consistency and optimization matter.
 
 ```
 Task → Memory Query → Selector → Swarm (parallel) → Judge Panel → Elo Update
@@ -31,12 +39,39 @@ Task → Memory Query → Selector → Swarm (parallel) → Judge Panel → Elo 
 
 ## Quick start
 
+### Prerequisites
+
+- **Python 3.12+**
+- At least one LLM API key:
+  - **Anthropic** (Claude) — recommended, required for best results
+  - **Google** (Gemini) — optional, adds provider diversity
+  - **OpenAI** (GPT) — optional, adds provider diversity
+- **Claude Code Pro/Team** — optional, enables free agent seeding and judging via skills
+
+### Install & run
+
 ```bash
 pip install -e ".[dev]"
-cp .env.example .env          # Add your API keys
+cp .env.example .env          # Add your API keys (at minimum, ANTHROPIC_API_KEY)
 mobius init                    # Create database
-mobius bootstrap               # Seed agents via API (~$1.50)
-# OR use /mobius-seed for free   (requires Claude Code Pro)
+```
+
+Bootstrap agents (choose one):
+
+```bash
+# Option A: API-driven (~$1.50 one-time cost, automated)
+mobius bootstrap
+
+# Option B: Claude Code (free, requires Pro/Team subscription)
+# In Claude Code, type: /mobius-seed
+
+# Option C: Domain-specific (free API cost, reads your codebase)
+mobius scout ./my-project --count 5
+```
+
+Run your first competition:
+
+```bash
 mobius run "Build a CLI that converts CSV to JSON"
 ```
 
@@ -86,13 +121,13 @@ Scout created 4 agents for my-project.
 
 ## Why Mobius?
 
-| Problem | How Mobius solves it |
-|---------|---------------------|
-| "Which model is best for X?" | Run them all. Let judges decide per-task. |
-| Model outputs vary wildly | 5 attempts + consensus judging smooths variance |
-| No ground truth for creative tasks | Cross-family panel eliminates single-model bias |
-| Agents degrade silently | Elo tracks performance over time; losers get evolved or retired |
-| Selection is manual guesswork | Vector memory recalls what worked on similar past tasks |
+| Problem | How Mobius solves it | Trade-off |
+|---------|---------------------|-----------|
+| Which model is best? | Run all in parallel; judges pick best per task | 3-5x token cost vs. single call |
+| High output variance | Consensus scoring from 3 judges reduces outliers | Judge disagreement requires tiebreaker logic |
+| Creative tasks lack ground truth | Cross-provider judges (Claude + Gemini + GPT) reduce vendor bias | Judges add ~$0.10 per match |
+| Agents degrade silently | Elo tracks performance over time; losers get evolved or retired | Requires match history; cold start is random |
+| Selection is manual guesswork | Vector memory recalls what worked on similar past tasks | Embedding similarity isn't perfect for all task types |
 
 ## Commands
 
@@ -103,7 +138,6 @@ mobius loop --rounds 10         # Self-improvement loop across varied tasks
 mobius leaderboard              # Elo rankings
 mobius scout ./src              # Auto-generate domain agents from your code
 mobius evolve backend           # Improve underperformers in a specialization
-mobius train "task" --rounds N  # Iterative training on a single challenge
 mobius explain                  # Show last match's judge reasoning
 mobius stats                    # Overview
 mobius agent list               # Browse agents
@@ -156,40 +190,44 @@ After each competition, the winning agent's task is embedded (all-MiniLM-L6-v2) 
 
 ## Architecture
 
+### Request → Execution → Judgment → Learning
+
 ```
-src/mobius/
-├── cli.py              # Typer CLI
-├── orchestrator.py     # Competition coordinator
-├── swarm.py            # Async parallel execution
-├── runner.py           # Provider dispatcher
-├── judge.py            # Cross-family judge panel
-├── tournament.py       # Elo rating system
-├── selector.py         # Agent selection strategies
-├── memory.py           # Vector similarity (sqlite-vec)
-├── registry.py         # Agent CRUD
-├── agent_builder.py    # Opus-powered agent creation
-├── models.py           # Pydantic data models
-├── config.py           # Configuration
-└── providers/
-    ├── base.py         # Abstract interface
-    ├── anthropic.py    # Claude models
-    ├── google.py       # Gemini models
-    ├── openai.py       # GPT models
-    └── openrouter.py   # Multi-model gateway
+┌─────────────────────────────────────────────────────────────┐
+│ CLI (cli.py) — Typer command handlers                       │
+└──────────────────────────┬──────────────────────────────────┘
+                           ↓
+┌─────────────────────────────────────────────────────────────┐
+│ Orchestrator (orchestrator.py) — Coordinates a match        │
+│  1. Select agents via selector.py (uses memory.py)          │
+│  2. Run agents in parallel via swarm.py                     │
+│  3. Judge outputs via judge.py + runner.py                  │
+│  4. Update Elo ratings via tournament.py                    │
+│  5. Log results to database (db.py)                         │
+└─────────────────────────────────────────────────────────────┘
 ```
+
+**Provider abstraction** — All model calls go through `providers/` (anthropic, google, openai, openrouter), each implementing the same async interface with rate limiting.
+
+**Data layer** — Pydantic models (`models.py`), SQLite with WAL mode (`db.py`), agent CRUD (`registry.py`), and vector similarity via sqlite-vec (`memory.py` + local Sentence-Transformers embeddings).
+
+**Evolution** — `agent_builder.py` uses Opus to create/refine agents; `tournament.py` handles Elo math; `selector.py` picks agents via Specialist, Diverse, or Ensemble strategies.
 
 ## Cost
 
-Mobius is designed to be cheap to run:
+Costs below are for typical tasks (500-2000 tokens per agent attempt):
 
-| What | Model tier | Cost |
-|------|-----------|------|
-| Swarm execution | Haiku / Flash / GPT-4o-mini | ~$0.01-0.05 per agent |
-| Judge panel (API) | Opus + Gemini Pro + GPT-4o | ~$0.10 per match |
-| Full competition | 5 agents + 3 judges | ~$0.15-0.35 |
-| Bootstrap (one-time) | Opus | ~$1.50 |
+| Component | Models | Cost | Notes |
+|-----------|--------|------|-------|
+| Swarm (5 agents) | Haiku / Flash / GPT-4o-mini | ~$0.01-0.05 | Parallel; scales with task length |
+| Judge panel | Opus + Gemini Pro + GPT-4o | ~$0.05-0.15 | Evaluates all 5 outputs |
+| Full competition | 5 agents + 3 judges | ~$0.10-0.25 | One round |
+| Bootstrap (one-time) | Opus | ~$1.50 | Creates initial agent pool |
+| Vector embeddings | Sentence-Transformers | $0 | Runs locally, no API cost |
 
-**Claude Code users**: `/mobius-seed` and `/mobius-judge` use your Opus subscription directly — same quality, zero API cost.
+**Claude Code users**: `/mobius-seed` and `/mobius-judge` use your Opus subscription directly — same quality, zero API cost. API calls are only needed for `mobius bootstrap` (one-time) and automated loops.
+
+*Costs estimated March 2025. Verify current pricing in your provider dashboards.*
 
 ## Configuration
 
@@ -198,10 +236,8 @@ Mobius is designed to be cheap to run:
 | `MOBIUS_DATA_DIR` | `data` | Where the database lives |
 | `MOBIUS_SWARM_SIZE` | `5` | Agents per competition |
 | `MOBIUS_BUDGET_USD` | `50.0` | Global spending cap |
-| `MOBIUS_AGENT_TIMEOUT_SECONDS` | `120` | Max time per agent execution |
-| `MOBIUS_AGENT_MAX_TURNS` | `10` | Max tool-use turns per agent |
 
-See [`config.py`](src/mobius/config.py) for all tunable parameters.
+These are the env-overridable settings. Additional parameters (Elo K-factor, promotion thresholds, embedding model, evolution triggers, retirement streaks, and more) can be tuned directly in [`config.py`](src/mobius/config.py).
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -44,10 +44,10 @@ Task → Memory Query → Selector → Swarm (parallel) → Judge Panel → Elo 
 ### Prerequisites
 
 - **Python 3.12+**
-- At least one LLM API key (Anthropic recommended — required for the default judge panel):
-  - **Anthropic** (Claude) — recommended, used by default judge panel
-  - **Google** (Gemini) — optional, adds provider diversity
-  - **OpenAI** (GPT) — optional, adds provider diversity
+- At least one LLM API key (more keys = better judge diversity):
+  - **Anthropic** (Claude) — recommended, included in default judge panel
+  - **Google** (Gemini) — optional, adds cross-family judging
+  - **OpenAI** (GPT) — optional, adds cross-family judging
 - **Claude Code subscription** — optional, enables free agent seeding and judging via skills
 
 ### Install & run
@@ -127,7 +127,7 @@ Scout created 5 agents for my-project.
 | Problem | How Mobius solves it | Trade-off |
 |---------|---------------------|-----------|
 | Which model is best? | Run all in parallel; judges pick best per task | 3-5x token cost vs. single call |
-| High output variance | Consensus scoring from 3 judges reduces outliers | Judge disagreement requires tiebreaker logic |
+| High output variance | Consensus scoring from 3 judges reduces outliers | Consensus can be noisy with small panels; ties resolved by score aggregation |
 | Creative tasks lack ground truth | Cross-provider judges (Claude + Gemini + GPT) reduce vendor bias | Judges add ~$0.10 per match |
 | Agents degrade silently | Elo tracks performance over time; losers get evolved or retired | Requires match history; cold start is random |
 | Selection is manual guesswork | Vector memory recalls what worked on similar past tasks | Embedding similarity isn't perfect for all task types |
@@ -211,7 +211,7 @@ After each competition, the winning agent's task is embedded (all-MiniLM-L6-v2) 
 └─────────────────────────────────────────────────────────────┘
 ```
 
-**Provider abstraction** — All model calls go through `providers/` (anthropic, google, openai, openrouter), each implementing the same async interface with concurrency control.
+**Provider abstraction** — All model calls go through `providers/` (anthropic, google, openai, openrouter), each implementing the same async interface. Concurrency is controlled at the swarm layer via semaphore.
 
 **Data layer** — Pydantic models (`models.py`), SQLite with WAL mode (`db.py`), agent CRUD (`registry.py`), and vector similarity via sqlite-vec (`memory.py` + local Sentence-Transformers embeddings).
 

--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ Task → Memory Query → Selector → Swarm (parallel) → Judge Panel → Elo 
 ### Prerequisites
 
 - **Python 3.12+**
-- At least one LLM API key:
-  - **Anthropic** (Claude) — recommended, required for best results
+- At least one LLM API key (Anthropic recommended — required for the default judge panel):
+  - **Anthropic** (Claude) — recommended, used by default judge panel
   - **Google** (Gemini) — optional, adds provider diversity
   - **OpenAI** (GPT) — optional, adds provider diversity
 - **Claude Code Pro/Team** — optional, enables free agent seeding and judging via skills
@@ -52,7 +52,7 @@ Task → Memory Query → Selector → Swarm (parallel) → Judge Panel → Elo 
 
 ```bash
 pip install -e ".[dev]"
-cp .env.example .env          # Add your API keys (at minimum, ANTHROPIC_API_KEY)
+cp .env.example .env          # Add your API keys (see .env.example for all options)
 mobius init                    # Create database
 ```
 
@@ -65,7 +65,7 @@ mobius bootstrap
 # Option B: Claude Code (free, requires Pro/Team subscription)
 # In Claude Code, type: /mobius-seed
 
-# Option C: Domain-specific (free API cost, reads your codebase)
+# Option C: Domain-specific (uses Opus API to analyze your codebase, ~$0.50)
 mobius scout ./my-project --count 5
 ```
 
@@ -148,7 +148,7 @@ mobius agent export <slug>      # Export agent as .claude/agents/ markdown
 
 ## Claude Code Skills (Free)
 
-If you use [Claude Code](https://claude.com/claude-code) with a Pro subscription, these skills replace the paid API equivalents:
+If you use [Claude Code](https://claude.com/claude-code) with a Pro/Team subscription, these skills replace the paid API equivalents:
 
 | Skill | Replaces | What it does |
 |-------|----------|-------------|
@@ -209,7 +209,7 @@ After each competition, the winning agent's task is embedded (all-MiniLM-L6-v2) 
 └─────────────────────────────────────────────────────────────┘
 ```
 
-**Provider abstraction** — All model calls go through `providers/` (anthropic, google, openai, openrouter), each implementing the same async interface with rate limiting.
+**Provider abstraction** — All model calls go through `providers/` (anthropic, google, openai, openrouter), each implementing the same async interface with concurrency control.
 
 **Data layer** — Pydantic models (`models.py`), SQLite with WAL mode (`db.py`), agent CRUD (`registry.py`), and vector similarity via sqlite-vec (`memory.py` + local Sentence-Transformers embeddings).
 
@@ -225,9 +225,10 @@ Costs below are for typical tasks (500-2000 tokens per agent attempt):
 | Judge panel | Opus + Gemini Pro + GPT-4o | ~$0.05-0.15 | Evaluates all 5 outputs |
 | Full competition | 5 agents + 3 judges | ~$0.10-0.25 | One round |
 | Bootstrap (one-time) | Opus | ~$1.50 | Creates initial agent pool |
+| Scout | Opus | ~$0.50 | Analyzes codebase, creates domain agents |
 | Vector embeddings | Sentence-Transformers | $0 | Runs locally, no API cost |
 
-**Claude Code users**: `/mobius-seed` and `/mobius-judge` use your Opus subscription directly — same quality, zero API cost. API calls are only needed for `mobius bootstrap` (one-time) and automated loops.
+**Claude Code users**: `/mobius-seed` and `/mobius-judge` use your Opus subscription directly — same quality, zero API cost. CLI commands (`mobius run`, `mobius bootstrap`, `mobius scout`) still require API keys.
 
 *Costs estimated March 2026. Verify current pricing in your provider dashboards.*
 

--- a/ideas.md
+++ b/ideas.md
@@ -1,0 +1,30 @@
+# Ideas
+
+Concepts worth revisiting. Emerged from competitions, brainstorming, or usage patterns.
+
+## Skills to Build
+
+### `/mobius-forge` — Two-Phase Generate→Test Competition
+Run a competition where agents produce artifacts (code, skills, configs), then a second wave of agents functionally tests those artifacts. Scores combine design quality and working reality. This was the most valuable pattern from the 2026-03-14 skill forge lab.
+
+### Match Replay / Post-Mortem
+After a competition, automatically analyze: why did the winner win? What specific weaknesses caused losses? Extract judge feedback into actionable evolution targets. Closes the run→evolve feedback loop. (Attempted in skill forge — concept was strong, execution had bugs.)
+
+## System Improvements
+
+### Agent Factory Agent
+An agent whose specialization is creating other agents. It identifies capability gaps, designs the agent (system prompt, tools, specializations), and registers it directly. Different from `/mobius-seed` because it's autonomous — it decides what's needed.
+
+### Self-Audit Competition
+A competition where agents identify Mobius's own limitations and propose fixes. Winning proposals get implemented. Like `/mobius-audit` but adversarial and focused on improvement proposals rather than health checks.
+
+### `mobius improve` Command
+Takes the winning output from a "system improvement" competition and applies it. Closes the loop: compete → judge → implement → re-audit → repeat.
+
+## Observations
+
+- Smiths (codebase analysis) consistently outperform scouts (web research) on tasks about THIS project
+- Minimalist agents produce more reliable code than ambitious ones
+- Haiku agents over-promise in documentation vs. what their code actually does
+- The `tools` field in agent DB is metadata only — subagents get all tools regardless
+- Web research agents (WebSearch/WebFetch) DO work in subagents but scouts didn't leverage them effectively

--- a/labs/2026-03-14-skill-forge.md
+++ b/labs/2026-03-14-skill-forge.md
@@ -1,0 +1,110 @@
+# Lab: Skill Forge Competition
+
+**Date:** 2026-03-14
+**Match ID:** ed90f3e2f7c841d5b7538a17c8c3f4af
+**Pattern:** Two-phase competition (generate → functional test)
+
+## Hypothesis
+
+Can Mobius agents design useful Claude Code skills? And can a second wave of agents validate whether those skills actually work?
+
+## Setup
+
+**Task:** Design a Claude Code skill for Mobius that saves developer time or improves the system. Output a complete SKILL.md with frontmatter and helper scripts.
+
+**6 agents, 2 tracks:**
+
+### Scouts (web research → adapt existing patterns)
+| Slug | Philosophy | Tools |
+|------|-----------|-------|
+| `skill-scout-trending` | Find high-traction GitHub skills, adapt for agent swarms | WebSearch, WebFetch, Read, Grep, Glob, Bash |
+| `skill-scout-ecosystem` | Research Claude Code ecosystem, find underutilized capabilities | WebSearch, WebFetch, Read, Grep, Glob, Bash |
+| `skill-scout-devtools` | Find dev tool integrations, wrap multi-step workflows | WebSearch, WebFetch, Read, Grep, Glob, Bash |
+
+### Smiths (analyze codebase → invent from scratch)
+| Slug | Philosophy | Tools |
+|------|-----------|-------|
+| `skill-smith-gaps` | Identify workflow gaps, design skills to fill them | Read, Grep, Glob, Bash |
+| `skill-smith-meta` | Close open feedback loops in the system | Read, Grep, Glob, Bash |
+| `skill-smith-minimal` | Smallest possible skill that solves a real problem | Read, Grep, Glob, Bash |
+
+All agents: Haiku model, spawned in parallel via subagents.
+
+## Phase 1: Generation Results
+
+| Agent | Skill Produced | Scope |
+|-------|---------------|-------|
+| Scout - Trending | `/mobius-experiment` | 850-line SKILL.md, 5 scripts. Reproducible A/B testing with statistical rigor. |
+| Scout - Ecosystem | `/mobius-analyze` | 146-line SKILL.md, 4 scripts. Battle matrices, rock-paper-scissors detection. |
+| Scout - DevTools | `/mobius-export` | SKILL.md + 2 scripts. YAML/JSON export/import for version control. |
+| Smith - Gap Analyzer | `/mobius-insight` | 592-line SKILL.md, 5 scripts. Analytics with 4 modes (analyze, genealogy, trends, optimize). |
+| Smith - Meta Improver | `/mobius-replay` | 202-line SKILL.md, 2 scripts. Match forensics and post-mortem analysis. |
+| Smith - Minimalist | `/mobius-profile` | Short SKILL.md, 1 script (145 lines). Agent deep-dive with challenger recommendations. |
+
+### Design Scores (Opus judge)
+
+| Agent | Correctness | Quality | Completeness | Total |
+|-------|------------|---------|-------------|-------|
+| Scout - Trending | 6 | 4 | 8 | 18 |
+| Scout - Ecosystem | 7 | 7 | 7 | 21 |
+| Scout - DevTools | 8 | 7 | 7 | 22 |
+| Smith - Gap Analyzer | 7 | 6 | 8 | 21 |
+| Smith - Meta Improver | 8 | 8 | 7 | 23 |
+| Smith - Minimalist | 9 | 9 | 7 | 25 |
+
+## Phase 2: Functional Testing
+
+A second wave of Haiku subagents attempted to run each skill's scripts against the live database.
+
+| Skill | Pass/Fail | Functional Score | Key Findings |
+|-------|-----------|-----------------|--------------|
+| `/mobius-profile` | PASS | 9/10 | All features work. Edge cases handled. Tested against live DB with 40 agents. |
+| `/mobius-export` | PASS | 9/10 | Flawless round-trip export→import. Zero data loss. All formats valid. |
+| `/mobius-insight` | PASS | 9/10 | All 5 scripts work, valid JSON. Genealogy empty (no evolve runs yet) but correctly reports it. |
+| `/mobius-analyze` | PASS | 8/10 | Full pipeline works. Unicode issue on Windows. RPS detection not actually implemented despite being promised. |
+| `/mobius-experiment` | PASS | 8/10 | Scripts parse and run but `run_experiment.py` simulates results rather than calling real Mobius CLI. |
+| `/mobius-replay` | PASS (bugs fixed) | 6/10 | 2 critical bugs: `json.loads` on plain UUID, f-string errors. Tester had to fix them. Missing promised features. |
+
+## Combined Rankings
+
+| Rank | Skill | Design | Functional | Combined |
+|------|-------|--------|-----------|----------|
+| 1 | `/mobius-profile` | 25 | 9 | 34 |
+| 2 | `/mobius-export` | 22 | 9 | 31 |
+| 3 | `/mobius-insight` | 21 | 9 | 30 |
+| 4 | `/mobius-analyze` | 21 | 8 | 29 |
+| 5 | `/mobius-replay` | 23 | 6 | 29 |
+| 6 | `/mobius-experiment` | 18 | 8 | 26 |
+
+## Findings
+
+### What worked
+- **Smiths dominated scouts.** All 3 codebase-analyzers outperformed web researchers. Having direct access to the code produced more relevant, testable skills.
+- **Minimalism won.** Fewer lines = fewer bugs. The 145-line profile script worked perfectly; the 850-line experiment framework simulated instead of integrating.
+- **Two-phase testing is essential.** Design scores and functional scores diverged significantly. `/mobius-replay` scored 2nd in design but last in functional testing (shipped with crashing bugs). You can't judge a skill by reading its SKILL.md.
+
+### What didn't work
+- **Scouts didn't leverage web research well.** Despite having WebSearch/WebFetch tools, the scouts produced skills that could have been designed without any web research. The trending scout produced the most over-engineered solution.
+- **Haiku agents over-promise.** SKILL.md descriptions claimed features that the scripts didn't implement (RPS detection in analyze, recommendations in replay).
+
+### Overlap discovered
+- `/mobius-export` overlaps with existing `mobius agent export <slug>` CLI command
+- `/mobius-insight` overlaps heavily with `mobius stats` + `mobius leaderboard`
+- `/mobius-profile` overlaps with `mobius agent show` but adds challenger recommendations (genuine new value)
+
+## Decisions
+
+- **Kept:** `/mobius-profile` — fills a real gap (challenger recommendations not available elsewhere)
+- **Removed:** The other 5 skill directories — overlap with existing CLI or not production-ready
+- **Ideas preserved:** See `ideas.md` for concepts worth revisiting
+
+## Meta: The Two-Phase Pattern
+
+The most valuable outcome wasn't any individual skill — it was the **generate → test** competition pattern itself. This is the closest thing to automated experimentation on agent output quality:
+
+1. Seed N agents with different philosophies
+2. Run them on a generative task (produce code/artifacts)
+3. Spawn a second wave of agents to functionally test the outputs
+4. Score on both design quality AND working reality
+
+This pattern should become a repeatable skill (`/mobius-forge` or similar).


### PR DESCRIPTION
## Summary

- **`labs/2026-03-14-skill-forge.md`** — First two-phase competition: 6 agents designed Claude Code skills, then 6 testers functionally validated them against the live DB. Full results, scores, and findings documented.
- **`/mobius-profile`** — Competition winner. Single-script skill that shows agent deep-dives with match history, win/loss analysis, and challenger recommendations. Tested and working.
- **`ideas.md`** — Living backlog of concepts that emerged from the competition (forge skill, match replay, agent factory, self-audit).

## Key Finding

The **generate → test** two-phase pattern was more valuable than any individual skill. Design scores and functional scores diverged significantly — one skill scored 2nd in design but last in functional testing (shipped with crashing bugs). This pattern should become repeatable.

Relates to #5 (mobius improve self-diagnosing loop)

## Test plan

- [x] `/mobius-profile` tested against live DB with 40 agents
- [x] Edge cases verified (0 matches, nonexistent agents)
- [x] Lab entry reviewed for accuracy against actual competition results

🤖 Generated with [Claude Code](https://claude.com/claude-code)