### PR TITLE
Fix memory system: lower thresholds, add dedup, store from free-mode

### DIFF
--- a/.claude/skills/mobius-judge/scripts/record_verdict.py
+++ b/.claude/skills/mobius-judge/scripts/record_verdict.py
@@ -15,7 +15,10 @@ from itertools import combinations
 sys.path.insert(0, "src")
 
 from mobius.config import get_config
-from mobius.db import init_db, row_to_dict
+from mobius.db import init_db, row_to_dict, vec_to_blob
+from mobius.embedder import embed
+from mobius.memory import Memory
+from mobius.models import MemoryEntry
 from mobius.registry import Registry
 from mobius.tournament import Tournament
 
@@ -39,9 +42,10 @@ def main():
     reasoning = args[2]
 
     config = get_config()
-    conn, _ = init_db(config)
+    conn, vec_available = init_db(config)
     registry = Registry(conn, config)
     tournament = Tournament(conn, config, registry)
+    memory = Memory(conn, config, vec_available)
 
     # Get the match
     if match_id:
@@ -121,6 +125,21 @@ def main():
         registry.update_stats(cid, won=(cid == full_winner_id))
 
     conn.commit()
+
+    # Store in vector memory so future selections benefit
+    task_text = match.get("task_description", "")
+    if task_text and full_winner_id:
+        try:
+            task_vec = embed(task_text, config)
+            memory_entry = MemoryEntry(
+                task_embedding=vec_to_blob(task_vec),
+                task_text=task_text,
+                winning_agent_id=full_winner_id,
+                score=max(scores.values()) if scores else 0.0,
+            )
+            memory.store(memory_entry)
+        except Exception as e:
+            print(f"Warning: failed to store memory entry: {e}", file=sys.stderr)
 
     # Print results
     winner = agents_by_id.get(full_winner_id)

--- a/src/mobius/config.py
+++ b/src/mobius/config.py
@@ -41,8 +41,8 @@ class MobiusConfig(BaseModel):
     embedding_model: str = "all-MiniLM-L6-v2"
     embedding_dim: int = 384
     memory_top_k: int = 5
-    similarity_specialist_threshold: float = 0.9
-    similarity_ensemble_threshold: float = 0.7
+    similarity_specialist_threshold: float = 0.5
+    similarity_ensemble_threshold: float = 0.3
 
     # Self-improvement
     max_agent_population: int = 50

--- a/src/mobius/config.py
+++ b/src/mobius/config.py
@@ -23,6 +23,7 @@ class MobiusConfig(BaseModel):
     agent_timeout_seconds: int = 120
     agent_max_turns: int = 10
     agent_budget_usd: float = 0.05
+    agent_max_output_tokens: int = 16384
 
     # Judge
     judge_models: list[dict[str, str]] = [

--- a/src/mobius/memory.py
+++ b/src/mobius/memory.py
@@ -35,7 +35,18 @@ class Memory:
         self.vec_available = vec_available
 
     def store(self, entry: MemoryEntry) -> None:
-        """Store a task outcome in memory."""
+        """Store a task outcome in memory, skipping duplicates."""
+        existing = self.conn.execute(
+            "SELECT id FROM memory WHERE task_text = ? AND winning_agent_id = ?",
+            (entry.task_text, entry.winning_agent_id),
+        ).fetchone()
+        if existing:
+            logger.debug(
+                "Duplicate memory entry for agent %s on task, skipping",
+                entry.winning_agent_id,
+            )
+            return
+
         row = dict_to_row(entry.model_dump(exclude={"task_embedding"}))
         cols = ", ".join(row.keys())
         placeholders = ", ".join(["?"] * len(row))

--- a/src/mobius/providers/anthropic.py
+++ b/src/mobius/providers/anthropic.py
@@ -75,7 +75,7 @@ class AnthropicProvider(Provider):
         try:
             response = await asyncio.wait_for(
                 client.messages.create(
-                    model=model, max_tokens=4096,
+                    model=model, max_tokens=16384,
                     system=system_prompt,
                     messages=[{"role": "user", "content": prompt}],
                 ),
@@ -115,7 +115,7 @@ class AnthropicProvider(Provider):
             for turn in range(max_turns):
                 response = await asyncio.wait_for(
                     client.messages.create(
-                        model=model, max_tokens=4096,
+                        model=model, max_tokens=16384,
                         system=system_prompt,
                         messages=messages,
                         tools=[ANTHROPIC_BASH_TOOL],

--- a/src/mobius/providers/google.py
+++ b/src/mobius/providers/google.py
@@ -123,7 +123,7 @@ class GoogleProvider(Provider):
         config = types.GenerateContentConfig(
             system_instruction=system_prompt,
             tools=[bash_tool],
-            max_output_tokens=4096,
+            max_output_tokens=16384,
         )
 
         contents = [types.Content(

--- a/src/mobius/providers/openai.py
+++ b/src/mobius/providers/openai.py
@@ -65,7 +65,7 @@ class OpenAIProvider(Provider):
                         {"role": "system", "content": system_prompt},
                         {"role": "user", "content": prompt},
                     ],
-                    max_tokens=4096,
+                    max_tokens=16384,
                 ),
                 timeout=timeout_seconds,
             )
@@ -110,7 +110,7 @@ class OpenAIProvider(Provider):
                         model=model,
                         messages=messages,
                         tools=[OPENAI_BASH_TOOL],
-                        max_tokens=4096,
+                        max_tokens=16384,
                     ),
                     timeout=timeout_seconds,
                 )

--- a/src/mobius/providers/openrouter.py
+++ b/src/mobius/providers/openrouter.py
@@ -78,7 +78,7 @@ class OpenRouterProvider(Provider):
                         {"role": "system", "content": system_prompt},
                         {"role": "user", "content": prompt},
                     ],
-                    max_tokens=4096,
+                    max_tokens=16384,
                 ),
                 timeout=timeout_seconds,
             )
@@ -123,7 +123,7 @@ class OpenRouterProvider(Provider):
                         model=model,
                         messages=messages,
                         tools=[OPENAI_BASH_TOOL],
-                        max_tokens=4096,
+                        max_tokens=16384,
                     ),
                     timeout=timeout_seconds,
                 )


### PR DESCRIPTION
- Lower similarity thresholds from 0.9/0.7 to 0.5/0.3 so memory actually influences agent selection (real similarities are 0.3-0.5)
- Add dedup check in memory.store() to prevent duplicate task+winner entries
- Store memory entries from free-mode matches via record_verdict.py so /mobius-run competitions feed back into the selection system

This pull request enhances the verdict recording script and memory management in the Mobius project. The main improvements involve storing match outcomes in vector memory for future retrieval, preventing duplicate memory entries, and adjusting similarity thresholds to make memory retrieval more permissive.

**Memory storage and retrieval improvements:**

* The `record_verdict.py` script now stores the winning agent and task description in vector memory after each verdict, enabling future matches to benefit from past outcomes. This uses the `embed` function and the `Memory` class to create and store a `MemoryEntry`. Errors during storage are caught and logged as warnings. [[1]](diffhunk://#diff-8f73fb73f2137c766666380d657c40d6a3c1eb625aef71a6721bd70c35346f33L18-R21) [[2]](diffhunk://#diff-8f73fb73f2137c766666380d657c40d6a3c1eb625aef71a6721bd70c35346f33L42-R48) [[3]](diffhunk://#diff-8f73fb73f2137c766666380d657c40d6a3c1eb625aef71a6721bd70c35346f33R129-R143)
* The `Memory.store` method now checks for duplicates before inserting a new memory entry, preventing redundant data storage for the same agent and task combination.

**Configuration changes:**

* The similarity thresholds for specialist and ensemble memory retrieval have been lowered (`similarity_specialist_threshold` from 0.9 to 0.5, and `similarity_ensemble_threshold` from 0.7 to 0.3) to make memory lookups more permissive and likely to return results.